### PR TITLE
Close the socket on default process method

### DIFF
--- a/src/qhttphandler.cpp
+++ b/src/qhttphandler.cpp
@@ -76,4 +76,5 @@ void QHttpHandler::process(QHttpSocket *socket, const QString &)
 {
     // The default response is simply a 404 error
     socket->writeError(QHttpSocket::NotFound);
+    socket->close();
 }


### PR DESCRIPTION
Just like in QObjectHandler after writing to the socket, the socket
should be close.