### PR TITLE
Range request and partial content support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC
     qfilesystemhandler.cpp
     qhttphandler.cpp
     qhttpparser.cpp
+    qhttprange.cpp
     qhttpserver.cpp
     qhttpsocket.cpp
     qibytearray.cpp

--- a/src/QHttpEngine/QHttpRange
+++ b/src/QHttpEngine/QHttpRange
@@ -1,0 +1,1 @@
+#include "qhttprange.h"

--- a/src/QHttpEngine/qhttprange.h
+++ b/src/QHttpEngine/qhttprange.h
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2016 Aleksei Ermakov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef QHTTPENGINE_QHTTPRANGE_H
+#define QHTTPENGINE_QHTTPRANGE_H
+
+#include <QString>
+
+#include "qhttpengine.h"
+
+class QHTTPENGINE_EXPORT QHttpRangePrivate;
+
+/**
+ * @brief HTTP range representation
+ * @headerfile qhttpparser.h QHttpEngine/QHttpParser
+ *
+ * This class provides a representation of HTTP range, described in RFC 7233
+ * and used when partial content is requested by client. When object is
+ * created, optional dataSize can be specified, so that relative ranges can
+ * be represented as absolute.
+ *
+ * Example:
+ * @code
+ * QHttpRange range(10, -1, 90);
+ * range.from();   //  10
+ * range.to();     //  89
+ * range.length(); //  80
+ *
+ * range = QHttpRange("-500", 1000);
+ * range.from();   // 500
+ * range.to();     // 999
+ * range.length(); // 500
+ *
+ * range = QHttpRange(0, -1);
+ * range.from();   //   0
+ * range.to();     //  -1
+ * range.length(); //  -1
+ *
+ * range = QHttpRange(range, 100);
+ * range.from();   //   0
+ * range.to();     //  99
+ * range.length(); // 100
+ * @endcode
+ *
+ */
+class QHTTPENGINE_EXPORT QHttpRange
+{
+public:
+
+    /**
+     * @brief Constructs QHttpRange by parsing range.
+     *
+     * Parses string representation range and constructs new QHttpRange.
+     * For raw header "Range: bytes=0-100" only "0-100" should be passed to
+     * constructor. dataSize may be supplied so that relative ranges could be
+     * represented as absolute values.
+     */
+    QHttpRange(const QString &range, qint64 dataSize = -1);
+
+    /**
+     * @brief Constructs QHttpRange, using from and to values.
+     *
+     * Initialises a new QHttpRange with from and to values. dataSize may be
+     * supplied so that relative ranges could be represented as
+     * absolute values.
+     */
+    QHttpRange(qint64 from, qint64 to, qint64 dataSize = -1);
+
+    /**
+     * @brief Constructs QHttpRange from other QHttpRange and dataSize.
+     *
+     * Initialises a new QHttpRange with from and to values of other
+     * QHttpRequest. Supplied dataSize is used instead of other dataSize.
+     */
+    QHttpRange(const QHttpRange &other, qint64 dataSize);
+
+    /**
+     * @brief Default QHttpRange constructor.
+     *
+     * Default empty QHttpRange is considered invalid.
+     */
+    QHttpRange();
+    ~QHttpRange();
+
+    QHttpRange& operator=(const QHttpRange &other);
+
+    /**
+     * @brief Returns starting position of range.
+     *
+     * If range is set as 'last N bytes' and dataSize is not set, returns -N.
+     *
+     * Example:
+     * @code
+     * QHttpRange range("-500");
+     * range.from();   // -500
+     * range.to();     //   -1
+     * range.length(); //  500
+     *
+     * range = QHttpRange(range, 800);
+     * range.from();   //  300
+     * range.to();     //  799
+     * range.length(); //  500
+     *
+     * range = QHttpRange("10-");
+     * range.from();   //   10
+     * range.to();     //   -1
+     * range.length(); //   -1
+     *
+     * range = QHttpRange(range, 100);
+     * range.from();   //   10
+     * range.to();     //   99
+     * range.length(); //   90
+     * @endcode
+     *
+     */
+    qint64 from() const;
+
+    /**
+     * @brief Returns ending position of range.
+     *
+     * If range is set as 'last N bytes' and dataSize is not set, returns -1.
+     * If ending position is not set, and dataSize is not set, returns -1.
+     *
+     * Example:
+     * @code
+     * QHttpRange range("-500");
+     * range.from();   // -500
+     * range.to();     //   -1
+     * range.length(); //  500
+     *
+     * range = QHttpRange(range, 800);
+     * range.from();   //  300
+     * range.to();     //  799
+     * range.length(); //  500
+     *
+     * range = QHttpRange("10-");
+     * range.from();   //   10
+     * range.to();     //   -1
+     * range.length(); //   -1
+     *
+     * range = QHttpRange(range, 100);
+     * range.from();   //   10
+     * range.to();     //   99
+     * range.length(); //   90
+     * @endcode
+     *
+     */
+    qint64 to() const;
+
+    /**
+     * @brief Returns length of range.
+     *
+     * If ending position is not set, and dataSize is not set, and range is
+     * not set as 'last N bytes', returns -1. If range is invalid, returns -1.
+     *
+     * Example:
+     * @code
+     * QHttpRange range("-500");
+     * range.from();   // -500
+     * range.to();     //   -1
+     * range.length(); //  500
+     *
+     * range = QHttpRange(range, 800);
+     * range.from();   //  300
+     * range.to();     //  799
+     * range.length(); //  500
+     *
+     * range = QHttpRange("10-");
+     * range.from();   //   10
+     * range.to();     //   -1
+     * range.length(); //   -1
+     *
+     * range = QHttpRange(range, 100);
+     * range.from();   //   10
+     * range.to();     //   99
+     * range.length(); //   90
+     * @endcode
+     *
+     */
+    qint64 length() const;
+
+    /**
+     * @brief Returns dataSize of range.
+     *
+     * If dataSize is not set, returns -1.
+     */
+    qint64 dataSize() const;
+
+    /**
+     * @brief Checks if range is valid
+     *
+     * Range is considered invalid if it is out of bounds, that is when this
+     * inequality is false - (from <= to < dataSize).
+     * When QHttpRange(const QString&) fails to parse range string, resulting
+     * range is also considered invalid.
+     *
+     * Example:
+     * @code
+     * QHttpRange range(1, 0, -1);
+     * range.isValid(); // false
+     *
+     * range = QHttpRange(512, 1024);
+     * range.isValid(); // true
+     *
+     * range = QHttpRange("-");
+     * range.isValid(); // false
+     *
+     * range = QHttpRange("abccbf");
+     * range.isValid(); // false
+     *
+     * range = QHttpRange(0, 512, 128);
+     * range.isValid(); // false
+     *
+     * range = QHttpRange(128, 64, 512);
+     * range.isValid(); // false
+     * @endcode
+     */
+    bool isValid() const;
+
+    /**
+     * @brief Returns representation suitable for Content-Range header.
+     *
+     * Example:
+     * @code
+     * QHttpRange range(0, 100, 1000);
+     * range.contentRange(); // "0-100/1000"
+     *
+     * // When resource size is unknown
+     * range = QHttpRange(512, 1024);
+     * range.contentRange(); // "512-1024/*"
+     *
+     * // if range request was bad, return resource size
+     * range = QHttpRange(1, 0, 1200);
+     * range.contentRange(); // "*\/1200"
+     * @endcode
+     */
+    QString contentRange() const;
+
+private:
+
+    QHttpRangePrivate *const d;
+    friend class QHttpRangePrivate;
+};
+
+#endif // QHTTPENGINE_QHTTPRANGE_H

--- a/src/QHttpEngine/qhttpsocket.h
+++ b/src/QHttpEngine/qhttpsocket.h
@@ -97,6 +97,8 @@ public:
     enum {
         /// Request was successful
         OK = 200,
+        /// Range request was successful
+        PartialContent = 206,
         /// Resource has moved permanently
         MovedPermanently = 301,
         /// Resource is available at an alternate URI

--- a/src/QHttpEngine/qiodevicecopier.h
+++ b/src/QHttpEngine/qiodevicecopier.h
@@ -76,6 +76,11 @@ public:
      */
     void setBufferSize(qint64 size);
 
+    /**
+     * @brief Set range of data to copy, if src device is not sequential
+     */
+    void setRange(qint64 from, qint64 to);
+
 Q_SIGNALS:
 
     /**

--- a/src/qhttprange.cpp
+++ b/src/qhttprange.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2016 Aleksei Ermakov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <QRegExp>
+
+#include "QHttpEngine/qhttprange.h"
+#include "qhttprange_p.h"
+
+QHttpRangePrivate::QHttpRangePrivate(QHttpRange *range)
+    : q(range)
+{
+}
+
+QHttpRange::QHttpRange(const QString &range, qint64 dataSize)
+    : d(new QHttpRangePrivate(this))
+{
+    QRegExp regExp("^(\\d*)-(\\d*)$");
+
+    int from = 0, to = -1;
+
+    if(regExp.indexIn(range.trimmed()) != -1) {
+        QString fromStr = regExp.cap(1);
+        QString toStr = regExp.cap(2);
+
+        // If both strings are empty - range is invalid. Setting to out of
+        // bounds range and returning.
+        if(fromStr.isEmpty() && toStr.isEmpty()) {
+            d->from = 1;
+            d->to = 0;
+            d->dataSize = -1;
+            return;
+        }
+
+        bool okFrom = true, okTo = true;
+
+        if(!fromStr.isEmpty()) {
+            from = fromStr.toInt(&okFrom);
+        }
+        if(!toStr.isEmpty()) {
+            to = toStr.toInt(&okTo);
+        }
+
+        // If failed to parse value - set to invalid range and return.
+        if(!okFrom) {
+            d->from = 1;
+            d->to = 0;
+            d->dataSize = -1;
+            return;
+        }
+
+        if(!okTo) {
+            d->from = 1;
+            d->to = 0;
+            d->dataSize = -1;
+            return;
+        }
+
+        // In case of 'last N bytes' range (Ex.: "Range: bytes=-500"),
+        // set from to -to and to to -1
+        if(fromStr.isEmpty()) {
+            from = -to;
+            to = -1;
+        }
+    } else { // If regexp didn't match - set to invalid range and return.
+        d->from = 1;
+        d->to = 0;
+        d->dataSize = -1;
+        return;
+    }
+
+    d->from = from;
+    d->to = to;
+    d->dataSize = dataSize;
+}
+
+QHttpRange::QHttpRange(qint64 from, qint64 to, qint64 dataSize)
+    : d(new QHttpRangePrivate(this))
+{
+    d->from = from;
+    d->to = to < 0 ? -1 : to;
+    d->dataSize = dataSize < 0 ? -1 : dataSize;
+}
+
+QHttpRange::QHttpRange(const QHttpRange &other, qint64 dataSize)
+    : d(new QHttpRangePrivate(this))
+{
+    d->from = other.d->from;
+    d->to = other.d->to;
+    d->dataSize = dataSize;
+}
+
+QHttpRange::QHttpRange()
+    : d(new QHttpRangePrivate(this))
+{
+    d->from = 1;
+    d->to = 0;
+    d->dataSize = -1;
+}
+
+QHttpRange::~QHttpRange()
+{
+    delete d;
+}
+
+QHttpRange& QHttpRange::operator=(const QHttpRange &other)
+{
+    if(&other != this) {
+        d->from = other.d->from;
+        d->to = other.d->to;
+        d->dataSize = other.d->dataSize;
+    }
+
+    return *this;
+}
+
+qint64 QHttpRange::from() const
+{
+    // Last N bytes requested
+    if(d->from < 0 && d->dataSize != -1) {
+        // Check if data is smaller then requested range
+        if(- d->from >= d->dataSize) {
+            return 0;
+        }
+        return d->dataSize + d->from;
+    }
+
+    // Check if d->from is bigger than d->to or d->dataSize
+    if((d->from > d->to && d->to != -1) ||
+            (d->from >= d->dataSize && d->dataSize != -1)) {
+        return 0;
+    }
+
+    return d->from;
+}
+
+qint64 QHttpRange::to() const
+{
+    // Last N bytes requested
+    if(d->from < 0 && d->dataSize != -1) {
+        return d->dataSize - 1;
+    }
+
+    // Skip first N bytes requested
+    if(d->from > 0 && d->to == -1 && d->dataSize != -1) {
+        return d->dataSize - 1;
+    }
+
+    // Check if d->from is bigger then d->to
+    if(d->from > d->to && d->to != -1) {
+        return d->from;
+    }
+
+    // When d->to overshoots dataSize
+    if((d->to >= d->dataSize || d->to == -1) && d->dataSize != -1) {
+        return d->dataSize - 1;
+    }
+
+    return d->to;
+}
+
+qint64 QHttpRange::length() const
+{
+    if(!isValid()) {
+        return -1;
+    }
+
+    // Last n bytes
+    if(d->from < 0) {
+        return -(d->from);
+    }
+
+    // From and to are set
+    if(d->to >= 0) {
+        return d->to - d->from + 1;
+    }
+
+    // From to to end
+    if(d->dataSize >= 0) {
+        return d->dataSize - d->from;
+    }
+
+    return -1;
+}
+
+qint64 QHttpRange::dataSize() const
+{
+    return d->dataSize;
+}
+
+bool QHttpRange::isValid() const
+{
+    // Valid cases:
+    // 1. "-500/1000"   => from: -500, to:  -1; dataSize: 1000
+    // 2. "10-/1000"    => from:   10, to:  -1; dataSize: 1000
+    // 3. "10-600/1000" => from:   10, to: 600; dataSize: 1000
+    // 4. "-500/*"      => from: -500, to:  -1; dataSize:   -1
+    // 5. "10-/*"       => from:   10, to:  -1; dataSize:   -1
+    // 6. "10-600/*"    => from:   10, to: 600; dataSize:   -1
+
+    // DataSize is set
+    if(d->dataSize >= 0) {
+        if(d->from < 0) { // Last n bytes
+            // Check if from is in range of dataSize
+            if(d->dataSize + d->from >= 0) {
+                return true;
+            }
+        } else {
+            if(d->to <= -1) { // To isn't set, range is up to the end
+                // Check if from is in range of dataSize
+                if(d->from < d->dataSize) {
+                    return true;
+                }
+            } else { // from, to and dataSize are set
+                if(d->from <= d->to && d->to < d->dataSize) {
+                    return true;
+                }
+            }
+        }
+    } else { // dataSize is not set
+        if(d->from < 0) { // Last n bytes
+            return true;
+        } else {
+            if(d->to <= -1) { // To isn't set, range is up to the end
+                return true;
+            } else { // from and to are set
+                if(d->from <= d->to) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+QString QHttpRange::contentRange() const
+{
+    QString fromStr, toStr, sizeStr = "*";
+
+    if(d->dataSize >= 0) {
+        if(isValid()) {
+            fromStr = QString::number(from());
+            toStr = QString::number(to());
+            sizeStr = QString::number(dataSize());
+        } else {
+            sizeStr = QString::number(dataSize());
+        }
+    } else {
+        if(isValid()) {
+            fromStr = QString::number(from());
+            toStr = QString::number(to());
+        } else {
+            return "";
+        }
+    }
+
+    if(fromStr.isEmpty() || toStr.isEmpty()) {
+        return QString("*/%1").arg(sizeStr);
+    }
+
+    return QString("%1-%2/%3").arg(fromStr, toStr, sizeStr);
+}

--- a/src/qhttprange_p.h
+++ b/src/qhttprange_p.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Aleksei Ermakov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef QHTTPENGINE_QHTTPRANGEPRIVATE_H
+#define QHTTPENGINE_QHTTPRANGEPRIVATE_H
+
+#include "QHttpEngine/qhttprange.h"
+
+class QHttpRangePrivate
+{
+public:
+
+    explicit QHttpRangePrivate(QHttpRange *range);
+
+    qint64 from;
+    qint64 to;
+    qint64 dataSize;
+
+private:
+
+    QHttpRange *const q;
+};
+
+#endif // QHTTPENGINE_QHTTPRANGEPRIVATE_H

--- a/src/qhttpsocket.cpp
+++ b/src/qhttpsocket.cpp
@@ -59,6 +59,7 @@ QByteArray QHttpSocketPrivate::statusReason(int statusCode) const
 {
     switch(statusCode) {
     case QHttpSocket::OK: return "OK";
+    case QHttpSocket::PartialContent: return "PARTIAL CONTENT";
     case QHttpSocket::MovedPermanently: return "MOVED PERMANENTLY";
     case QHttpSocket::Found: return "FOUND";
     case QHttpSocket::BadRequest: return "BAD REQUEST";

--- a/src/qiodevicecopier_p.h
+++ b/src/qiodevicecopier_p.h
@@ -41,6 +41,9 @@ public:
 
     qint64 bufferSize;
 
+    qint64 rangeFrom;
+    qint64 rangeTo;
+
 private Q_SLOTS:
 
     void onReadyRead();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TESTS
     TestQFilesystemHandler
     TestQHttpHandler
     TestQHttpParser
+    TestQHttpRange
     TestQHttpServer
     TestQHttpSocket
     TestQIByteArray

--- a/tests/TestQHttpRange.cpp
+++ b/tests/TestQHttpRange.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2016 Aleksei Ermakov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <QObject>
+#include <QString>
+#include <QTest>
+
+#include <QHttpEngine/QHttpRange>
+
+class TestQHttpRange : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    TestQHttpRange();
+
+private Q_SLOTS:
+
+    void testDefaultConstructor();
+    void testAssignmentOperator();
+
+    void testFromToLength_data();
+    void testFromToLength();
+
+    void testIsValid_data();
+    void testIsValid();
+
+    void testParseFromString_data();
+    void testParseFromString();
+
+    void testContentRange_data();
+    void testContentRange();
+};
+
+TestQHttpRange::TestQHttpRange()
+{
+}
+
+void TestQHttpRange::testDefaultConstructor()
+{
+    QHttpRange range;
+
+    QCOMPARE(range.isValid(), false);
+}
+
+void TestQHttpRange::testAssignmentOperator()
+{
+    QHttpRange range;
+    QHttpRange otherRange(100, 200, -1);
+
+    range = otherRange;
+
+    QCOMPARE(range.isValid(), true);
+    QCOMPARE(range.from(), 100);
+    QCOMPARE(range.to(), 200);
+}
+
+void TestQHttpRange::testFromToLength_data()
+{
+    QTest::addColumn<int>("inFrom");
+    QTest::addColumn<int>("inTo");
+    QTest::addColumn<int>("inDataSize");
+    QTest::addColumn<int>("from");
+    QTest::addColumn<int>("to");
+    QTest::addColumn<int>("length");
+
+    QTest::newRow("Last 500 bytes")
+            << -500 << -1 << -1
+            << -500 << -1 << 500;
+
+    QTest::newRow("Last 500 bytes with 800 dataSize")
+            << -500 << -1 << 800
+            << 300 << 799 << 500;
+
+    QTest::newRow("Skip first 10 bytes")
+            << 10 << -1 << -1
+            << 10 << -1 << -1;
+
+    QTest::newRow("Skip first 10 bytes with 100 dataSize")
+            << 10 << -1 << 100
+            << 10 << 99 << 90;
+}
+
+void TestQHttpRange::testFromToLength()
+{
+    QFETCH(int, inFrom);
+    QFETCH(int, inTo);
+    QFETCH(int, inDataSize);
+    QFETCH(int, from);
+    QFETCH(int, to);
+    QFETCH(int, length);
+
+    QHttpRange range(inFrom, inTo, inDataSize);
+
+    QCOMPARE(range.from(), from);
+    QCOMPARE(range.to(), to);
+    QCOMPARE(range.length(), length);
+}
+
+void TestQHttpRange::testIsValid_data()
+{
+    QTest::addColumn<int>("from");
+    QTest::addColumn<int>("to");
+    QTest::addColumn<int>("dataSize");
+    QTest::addColumn<bool>("valid");
+
+    QTest::newRow("Normal range")
+            << 0 << 100 << -1 << true;
+
+    QTest::newRow("Normal range with 'dataSize'")
+            << 0 << 99 << 100 << true;
+
+    QTest::newRow("Last N bytes")
+            << -500 << -1 << -1 << true;
+
+    QTest::newRow("Last N bytes with 'dataSize'")
+            << -500 << -1 << 500 << true;
+
+    QTest::newRow("Skip first N bytes")
+            << 10 << -1 << -1 << true;
+
+    QTest::newRow("Skip first N bytes with 'dataSize'")
+            << 10 << -1 << 500 << true;
+
+    QTest::newRow("OutOfBounds 'to' > 'from'")
+            << 100 << 50 << -1 << false;
+
+    QTest::newRow("OutOfBounds 'from' > 'dataSize'")
+            << 100 << 200 << 150 << false;
+
+    QTest::newRow("Last N bytes where N > 'dataSize'")
+            << -500 << -1 << 499 << false;
+
+    QTest::newRow("Skip first N bytes where N > 'dataSize'")
+            << 500 << -1 << 499 << false;
+}
+
+void TestQHttpRange::testIsValid()
+{
+    QFETCH(int, from);
+    QFETCH(int, to);
+    QFETCH(int, dataSize);
+    QFETCH(bool, valid);
+
+    QHttpRange range(from, to, dataSize);
+
+    QCOMPARE(range.isValid(), valid);
+}
+
+void TestQHttpRange::testParseFromString_data()
+{
+    QTest::addColumn<QString>("data");
+    QTest::addColumn<int>("dataSize");
+    QTest::addColumn<bool>("valid");
+    QTest::addColumn<int>("from");
+    QTest::addColumn<int>("to");
+    QTest::addColumn<int>("length");
+
+    QTest::newRow("Normal range")
+            << "0-99" << -1
+            << true << 0 << 99 << 100;
+
+    QTest::newRow("Normal range with 'dataSize'")
+            << "0-99" << 100
+            << true << 0 << 99 << 100;
+
+    QTest::newRow("Last N bytes")
+            << "-256" << -1
+            << true << -256 << -1 << 256;
+
+    QTest::newRow("Last N bytes with 'dataSize'")
+            << "-256" << 256
+            << true << 0 << 255 << 256;
+
+    QTest::newRow("Skip first N bytes")
+            << "100-" << -1
+            << true << 100 << -1 << -1;
+
+    QTest::newRow("Skip first N bytes with 'dataSize'")
+            << "100-" << 200
+            << true << 100 << 199 << 100;
+
+    QTest::newRow("OutOfBounds 'to' > 'from'")
+            << "100-50" << -1
+            << false;
+
+    QTest::newRow("OutOfBounds 'from' > 'dataSize'")
+            << "0-200" << 100
+            << false;
+
+    QTest::newRow("Last N bytes where N > 'dataSize'")
+            << "-500" << 200
+            << false;
+
+    QTest::newRow("Skip first N bytes where N > 'dataSize'")
+            << "100-" << 100
+            << false;
+
+    QTest::newRow("Bad input: '-'")
+            << "-" << -1
+            << false;
+
+    QTest::newRow("Bad input: 'abc-def'")
+            << "abc-def" << -1
+            << false;
+
+    QTest::newRow("Bad input: 'abcdef'")
+            << "abcdef" << -1
+            << false;
+}
+
+void TestQHttpRange::testParseFromString()
+{
+    QFETCH(QString, data);
+    QFETCH(int, dataSize);
+    QFETCH(bool, valid);
+
+    QHttpRange range(data, dataSize);
+
+    QCOMPARE(range.isValid(), valid);
+
+    if(valid) {
+        QFETCH(int, from);
+        QFETCH(int, to);
+        QFETCH(int, length);
+
+        QCOMPARE(range.from(), from);
+        QCOMPARE(range.to(), to);
+        QCOMPARE(range.length(), length);
+    }
+}
+
+void TestQHttpRange::testContentRange_data()
+{
+    QTest::addColumn<int>("from");
+    QTest::addColumn<int>("to");
+    QTest::addColumn<int>("dataSize");
+    QTest::addColumn<QString>("contentRange");
+
+    QTest::newRow("Normal range with 'dataSize'")
+            << 0 << 100 << 1000
+            << "0-100/1000";
+
+    QTest::newRow("Normal range without 'dataSize'")
+            << 0 << 100 << -1
+            << "0-100/*";
+
+    QTest::newRow("Invalid range with 'dataSize'")
+            << 100 << 10 << 1200
+            << "*/1200";
+
+    QTest::newRow("Invalid range without 'dataSize'")
+            << 100 << 10 << -1
+            << "";
+}
+
+void TestQHttpRange::testContentRange()
+{
+    QFETCH(int, from);
+    QFETCH(int, to);
+    QFETCH(int, dataSize);
+    QFETCH(QString, contentRange);
+
+    QHttpRange range(from, to, dataSize);
+
+    QCOMPARE(range.contentRange(), contentRange);
+}
+
+
+QTEST_MAIN(TestQHttpRange)
+#include "TestQHttpRange.moc"


### PR DESCRIPTION
Hi,

This pull request contains implementation of HTTP ranges (RFC 2616, RFC 7233) and additions to QFilesystemHandler and QIODeviceCopier to support partial content requests. Although this implementation lacks multipart reply support, it already allows to stream video/audio content with seeking support and allows resuming on interrupted downloads. Additionally, unit tests are implemented for all new features.

Please review this pull request and help me find a best way to merge it (after the review). Should it be merged to new-features or to master?

Regards,
Aleksei