### PR TITLE
Fixes issue #12, closes socket when done

### DIFF
--- a/src/qfilesystemhandler.cpp
+++ b/src/qfilesystemhandler.cpp
@@ -85,6 +85,9 @@ void QFilesystemHandlerPrivate::processFile(QHttpSocket *socket, const QString &
     QIODeviceCopier *copier = new QIODeviceCopier(file, socket);
     connect(copier, &QIODeviceCopier::finished, copier, &QIODeviceCopier::deleteLater);
     connect(copier, &QIODeviceCopier::finished, file, &QFile::deleteLater);
+    connect(copier, &QIODeviceCopier::finished, [socket]() {
+        socket->close();
+    });
 
     qint64 fileSize = file->size();
 

--- a/src/qobjecthandler.cpp
+++ b/src/qobjecthandler.cpp
@@ -90,9 +90,11 @@ void QObjectHandler::process(QHttpSocket *socket, const QString &path)
     // already the case, otherwise, wait until the rest of it arrives
     if (!m.readAll || socket->bytesAvailable() >= socket->contentLength()) {
         d->invokeSlot(socket, m);
+        socket->close();
     } else {
         connect(socket, &QHttpSocket::readChannelFinished, [this, socket, m]() {
             d->invokeSlot(socket, m);
+            socket->close();
         });
     }
 }


### PR DESCRIPTION
Closing the socket after calling the invokeSlot and not in QHttpServer
after process, because the invocation can be deferred if more data
needs to be read from the socket, so closing the socket after calling
invokeSlot guarantees that the socket is close when the slot finishes.