### PR TITLE
Fixed some gcc compiler warnings when using stricter options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/CMakeLists.txt
 /CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-/CMakeLists.txt
 /CMakeLists.txt.user

--- a/src/src/proxysocket.cpp
+++ b/src/src/proxysocket.cpp
@@ -137,6 +137,7 @@ void ProxySocket::onUpstreamReadyRead()
 
 void ProxySocket::onUpstreamError(QAbstractSocket::SocketError socketError)
 {
+    Q_UNUSED(socketError);
     if (mHeadersParsed) {
         mDownstreamSocket->close();
     } else {

--- a/src/src/qiodevicecopier_p.h
+++ b/src/src/qiodevicecopier_p.h
@@ -36,6 +36,8 @@ class QIODeviceCopierPrivate : public QObject
 {
     Q_OBJECT
 
+    QIODeviceCopier *const q;
+
 public:
 
     QIODeviceCopierPrivate(QIODeviceCopier *copier, QIODevice *srcDevice, QIODevice *destDevice);
@@ -56,8 +58,6 @@ public Q_SLOTS:
     void nextBlock();
 
 private:
-
-    QIODeviceCopier *const q;
 };
 
 }

--- a/src/src/server.cpp
+++ b/src/src/server.cpp
@@ -33,8 +33,8 @@ using namespace QHttpEngine;
 
 ServerPrivate::ServerPrivate(Server *httpServer)
     : QObject(httpServer),
-      q(httpServer),
-      handler(0)
+      handler(0),
+      q(httpServer)
 {
 }
 

--- a/src/src/socket.cpp
+++ b/src/src/socket.cpp
@@ -116,6 +116,8 @@ void SocketPrivate::onReadyRead()
     case ReadFinished:
         readBuffer.clear();
         break;
+    default:
+        break;
     }
 }
 

--- a/src/src/socket_p.h
+++ b/src/src/socket_p.h
@@ -34,6 +34,8 @@ class SocketPrivate : public QObject
 {
     Q_OBJECT
 
+    Socket*const q;
+
 public:
 
     SocketPrivate(Socket *httpSocket, QTcpSocket *tcpSocket);
@@ -80,7 +82,6 @@ private:
     bool readHeaders();
     void readData();
 
-    Socket*const q;
 };
 
 }


### PR DESCRIPTION
I had a project that mandated the use of -Wall -Wextra -Werror
This resulted in a few build errors, such as incorrect member initializer order, unused parameter, missing default in switch statement.
So, I cleaned those up, and thought this might be of use.

Note There is still a '/* within comment' issue with line 184 of range.h - not sure what the best approach to fixing that is.

Anyway - QHttpEngine works a treat - much appreciated ! If there is anything I can help with, then let me know.

Cheers,
Judd
