### PR TITLE
Add SSE awareness to QHttpEngine::Socket

### DIFF
--- a/src/include/qhttpengine/socket.h
+++ b/src/include/qhttpengine/socket.h
@@ -312,6 +312,14 @@ public:
     void setHeaders(const HeaderMap &headers);
 
     /**
+    * @brief Set the SSEEnabled flag
+     *
+     * Causes calls to write methods on the socket to leave connection open
+     * It will also not provide content length to prevent clients from closing connections
+    */
+   void setSSEEnabled(bool enabled = false);
+
+    /**
      * @brief Write response headers to the socket
      *
      * This method should not be invoked after the response headers have been
@@ -367,6 +375,7 @@ private:
 
     SocketPrivate *const d;
     friend class SocketPrivate;
+    bool sseEnabled;
 };
 
 }


### PR DESCRIPTION
Allow the user to set sseEnabled on a socket basis in order for the socket not to be close on writes and redirects.

This keeps the connection open for a constant stream of messages as defined per SSE.